### PR TITLE
clean Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -16,17 +16,10 @@ all: $(PROG)
 boot.h: boot.lua
 	xxd -i boot.lua > boot.h
 
-%.o: %.c
-	$(CC) -c $(CFLAGS) -o $@ $^
-
-engine.c: boot.h
-
+engine.o: boot.h
 
 $(PROG): main.o config.o engine.o framebuffer.o net.o
 	$(CC) -o $(PROG) $^ $(LDFLAGS)
 
-
 clean:
-	rm -f *.o
-	rm -rf *.o*
-	rm -f $(PROG) 
+	rm -rf *.o $(PROG) boot.h


### PR DESCRIPTION
Using `$<` (first dependency) instead of `$^` (all) for the `%.o` rule
means the `boot.h` dependency can correctly be attached to the `.o`
(otherwise it doesn't rebuild the executable when the Lua file changes).

But actually `make` has a builtin rule for `%.o`, and so the whole thing
can go.

Also cleaned up the `clean` rule – vim `.` (repeat last edit) accident?